### PR TITLE
build(flake): add tauri dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
         ];
         buildInputs = with pkgs; [
           rustToolchain openssl cargo-tauri
-        ] ++ lib.optionals stdenv.isLinux [ glib gtk3 webkitgtk libsoup ]
+        ] ++ lib.optionals stdenv.isLinux [ pkg-config glib gtk3 webkitgtk libsoup ]
           ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.WebKit ];
       in {
         devShells.default = pkgs.mkShell {

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,5 @@
 {
-  description = "Dev environment for Rust based on Nix flakes";
-
+  description = "Dev environment for Rust and Tauri 2.0 based on Nix flakes";
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
@@ -9,26 +8,38 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
-
   outputs = { self, nixpkgs, flake-utils, fenix }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs = nixpkgs.legacyPackages.${system};
-        rustToolchain = fenix.packages.${system}.minimal.toolchain;
-      in
-      {
+        overlays = [ fenix.overlays.default (import ./nix/overlays) ];
+        pkgs = import nixpkgs { inherit system overlays; };
+        rustToolchain = pkgs.fenix.stable.withComponents [
+          "cargo" "rustc" "rust-src" "clippy" "rustfmt"
+        ];
+        buildInputs = with pkgs; [
+          rustToolchain openssl cargo-tauri
+        ] ++ lib.optionals stdenv.isLinux [ glib gtk3 webkitgtk libsoup ]
+          ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.WebKit ];
+      in {
         devShells.default = pkgs.mkShell {
-          buildInputs = [
-            rustToolchain
-          ];
+          inherit buildInputs;
+          shellHook = ''
+            export PATH=${pkgs.lib.makeBinPath buildInputs}:$PATH
+          '';
         };
-
-        checks.default = pkgs.runCommand "check-rust-env" {
-          buildInputs = [ rustToolchain ];
+        checks.default = pkgs.runCommand "check-rust-tauri-env" {
+          inherit buildInputs;
         } ''
-          if ! command -v rustc > /dev/null || ! command -v cargo > /dev/null; then
-            exit 1
-          fi
+          export PATH=${pkgs.lib.makeBinPath buildInputs}:$PATH
+          command -v rustc > /dev/null && command -v cargo > /dev/null || { echo "Rust toolchain not found"; exit 1; }
+          command -v cargo-tauri > /dev/null || { echo "Tauri CLI not found"; exit 1; }
+          cargo_tauri_version=$(cargo-tauri --version)
+          [[ $cargo_tauri_version == tauri-cli* && $cargo_tauri_version == *2.0.0* ]] || { echo "Incorrect Tauri CLI version: $cargo_tauri_version"; exit 1; }
+          ${pkgs.lib.optionalString pkgs.stdenv.isLinux ''
+            pkg-config --exists gtk+-3.0 || { echo "GTK3 not found"; exit 1; }
+            pkg-config --exists webkit2gtk-4.0 || { echo "WebKitGTK not found"; exit 1; }
+          ''}
+          echo "All checks passed"
           touch $out
         '';
       }

--- a/nix/overlays/cargo-tauri.nix
+++ b/nix/overlays/cargo-tauri.nix
@@ -1,0 +1,40 @@
+{ lib
+, stdenv
+, rustPlatform
+, fetchFromGitHub
+, openssl
+, pkg-config
+, glibc
+, libsoup
+, cairo
+, gtk3
+, webkitgtk
+, darwin
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "tauri";
+  version = "2.0.0-beta.25";
+  
+  src = fetchFromGitHub {
+    owner = "tauri-apps";
+    repo = "tauri";
+    rev = "tauri-v${version}";
+    hash = "sha256-zVC+W34LPeYcdJoOt7jAr6iL/RV3QKF8c+8D0lDavtA=";
+  };
+
+  sourceRoot = "${src.name}/tooling/cli";
+  cargoHash = "sha256-vRejrAi7h0WvCOYGzd1WA51JMz1w7YuCiw/SDYqKOck=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ openssl ]
+    ++ lib.optionals stdenv.isLinux [ glibc libsoup cairo gtk3 webkitgtk ]
+    ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+      CoreServices
+      Security
+      SystemConfiguration
+    ]);
+
+  meta.mainProgram = "cargo-tauri";
+}

--- a/nix/overlays/default.nix
+++ b/nix/overlays/default.nix
@@ -1,0 +1,5 @@
+final: prev: let
+  cargo-tauri = prev.callPackage ./cargo-tauri.nix {};
+in {
+  inherit cargo-tauri;
+}


### PR DESCRIPTION
### Description

Adds Tauri dependencies to flake.nix. It utilizes an overlay to enable the latest (2.0) version of Tauri with cargo-tauri.

### Context

So that Tauri development environments are consistent across environments.

### Related issues and pull requests

closes GH-13