### PR TITLE
ci: add unit testing to build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Check flake health
+      - name: Check Flake Health
         uses: DeterminateSystems/flake-checker-action@v9
 
   build:
@@ -24,8 +24,11 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v14
-      - name: Run the Magic Nix Cache
+      - name: Run Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@v8
-      - name: Run Nix flake checks
+      - name: Run Nix Flake Checks
         run: |
           nix flake check
+      - name: Run Unit Tests
+        run: |
+          nix develop -c pnpm run test:unit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Run Nix Flake Checks
         run: |
           nix flake check
+      - name: Install Dependencies
+        run: |
+          nix develop -c pnpm install
       - name: Run Unit Tests
         run: |
           nix develop -c pnpm run test:unit

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -19,9 +19,9 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v14
-      - name: Run the Magic Nix Cache
+      - name: Run Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@v8
-      - name: Check flake health
+      - name: Check Flake Health
         uses: DeterminateSystems/flake-checker-action@v9
       - name: Update flake.lock
         uses: DeterminateSystems/update-flake-lock@v24

--- a/package.json
+++ b/package.json
@@ -12,8 +12,9 @@
 		"lint": "prettier --check . && eslint .",
 		"format": "prettier --write .",
 		"test:integration": "playwright test",
-    "test:integration:ui": "playwright test --ui",
-		"test:unit": "vitest"
+		"test:integration:ui": "playwright test --ui",
+		"test:unit": "vitest --run",
+		"test:unit:watch": "vitest"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.28.1",


### PR DESCRIPTION
### Description

Adds [Vitest](https://vitest.dev/) unit testing to the CI

### Context

So builds don't pass with failing tests. Sets us up to add coverage checks too.