### PR TITLE
ci: quick fix for dependabot with firebase

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -51,6 +51,7 @@ jobs:
           name: build
           path: build
       - name: Deploy to Firebase Preview
+        if: github.actor != 'dependabot[bot]'
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description

Skips preview deploy for dependabot

### Context

This is not the strategic approach, but still should allow dependabot to make changes