### PR TITLE
ci(firebase): modify workflow so that preview only deploys on src

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -43,9 +43,25 @@ jobs:
           name: build
           path: build
 
-  deploy-preview:
-    needs: build
+  changes:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    steps:
+        # For pull requests it's not necessary to checkout the code
+        - uses: dorny/paths-filter@v3
+          id: filter
+          with:
+            filters: |
+              src:
+                - 'src/**'
+
+  deploy-preview:
+    needs: [build, changes]
+    runs-on: ubuntu-latest
+    if: ${{ needs.changes.outputs.src == 'true' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
### Description

Checks for src folder changes before running deploy-preview.

### Context

Less deploys

### Additional context

Uses:
https://github.com/dorny/paths-filter

### Related issues and pull requests

closes GH-47